### PR TITLE
データベース設計書の修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 |------|----|-------|
 |text|text|なし|
 |image|string |なし|
-|user_id|references|foreign_key: true|
-|group_id |references|foreign_key: true|
+|user|references|foreign_key: true|
+|group |references|foreign_key: true|
 
 
 ### Association
@@ -32,8 +32,8 @@
 
 |Column|Type|Options|
 |------|----|-------|
-|user_id|references|foreign_key: true|
-|group_id|references|foreign_key: true|
+|user|references|foreign_key: true|
+|group|references|foreign_key: true|
 
 ### Association
 - belongs_to :group

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 |------|----|-------|
 |text|text|なし|
 |image|string |なし|
-|member_id|integer|foreign_key: true|
-|group_id |integer|foreign_key: true|
+|user_id|references|foreign_key: true|
+|group_id |references|foreign_key: true|
 
 
 ### Association
 - belongs_to :user
-- belongs_to :groupe
+- belongs_to :group
 
 
 ## usersテーブル
@@ -25,21 +25,21 @@
 ### Association
 - has_many :messages
 - has_many :group_members
-- has_many :groupes, through: :group_members
+- has_many :groups, through: :group_members
 
 
 ## group_membersテーブル
 
 |Column|Type|Options|
 |------|----|-------|
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
+|user_id|references|foreign_key: true|
+|group_id|references|foreign_key: true|
 
 ### Association
 - belongs_to :group
 - belongs_to :user
 
-## groupesテーブル
+## groupsテーブル
 |Column| Type|Options|
 |------|-----|-------|
 |name|string|null: false|


### PR DESCRIPTION
# What
・groupsを [ groupes ]と書いていた場所の修正
・外部キーの型を[ references ]に変更
・名前が間違っていたカラムの修正

# Why
・サーバーとデータベース間の情報のやり取りを正確なものにするため。