### PR TITLE
メッセージ送信機能の実装、投稿した内容をビューに反映させる処理

### DIFF
--- a/app/assets/stylesheets/_leftbody.scss
+++ b/app/assets/stylesheets/_leftbody.scss
@@ -3,17 +3,16 @@
   width: 300px;
   height: 100vh;
   background-color: #2f3e51;
-  padding-top: 20px;
   .user {
     @include left-side-position(25px, 20px, 15px);
     height: 15%;
     background-color: #253141;
     box-sizing: border-box;
     &__name {
-      color: $text;
       font-size: ($base_font + 4px);
       font-weight: bold;
-      float: left
+      float: left;
+      color: $text;
     }
     &__icon {
         left: 155px;
@@ -34,11 +33,18 @@
     @include left-side-position(5px, 0, 5px,);
     color: $text;
     font-size: ($base_font - 1);
+    a{
+    color: $text;
+    text-decoration: none;
+    }
+    a:visited {
+    color: $text;
+    }
     }
     &__info {
       @include left-side-position(5px, 5px, 5px,);
-      color: $text;
       font-size: ($base_font - 5);
+      color: $text;
     }
   }
 }

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -2,7 +2,8 @@ class GroupsController < ApplicationController
   before_action :set_group, only: [:edit, :update]
 
   def index
-    @groups = current_user.groups.all.order('id DESC')
+    @groups = current_user.groups
+
   end
 
   def new

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,16 +1,17 @@
 class MessagesController < ApplicationController
-  before_action :set_group_user, only: [:index, :new, :create]
+  before_action :set_group, only: [:index]
 
   def index
-    @messages = @group.messages.order('id ASC')
-    @message = Message.new
+    @groups = current_user.groups
+    @messages = @group.messages
+    @message = current_user.messages.new
   end
 
   def new
   end
 
   def create
-    @message = Message.new(message_params)
+    @message = current_user.messages.new(message_params)
     if @message.save
       redirect_to group_messages_path, notice: "メッセージが送信されました"
     else
@@ -21,12 +22,12 @@ class MessagesController < ApplicationController
 
   private
 
-  def set_group_user
+  def set_group
     @group = Group.find(params[:group_id])
   end
 
   def message_params
-    params.require(:message).permit(:text, :image).merge(user_id: current_user.id, group_id: params[:group_id])
+    params.require(:message).permit(:text, :image).merge(group_id: params[:group_id])
   end
 
 end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -14,7 +14,7 @@ class ImageUploader < CarrierWave::Uploader::Base
     "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
   end
 
-  process resize_to_limit: [300, 200, "Center"]
+  process resize_to_limit: [300, 200]
 
   # Provide a default URL as a default if there hasn't been a file uploaded:
   # def default_url(*args)

--- a/app/views/groups/_index.html.haml
+++ b/app/views/groups/_index.html.haml
@@ -1,0 +1,11 @@
+.group
+  .group_link
+  %p.group__name= link_to group.name, group_messages_path(group)
+  %p.group__info
+    - if group.messages.present?
+      - if group.messages.last.text.empty?
+        = "画像が投稿されています"
+      - else
+        = group.messages.last.text
+    - else
+      = "まだメッセージはありません"

--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -1,6 +1,6 @@
 .left-contents
   .user
-    %p.user__name name
+    %p.user__name= current_user.name
     .user__icon
       .user__icon__mark
         = link_to new_group_path do
@@ -8,8 +8,6 @@
       .user__icon__mark
         = link_to edit_user_registration_path do
           %i.fa.fa-cog
-  - @groups.each do |group|
-    .group
-      %p.group__name= group.name
-      %p.group__info よろしくお願いします
+  = render partial: "index", collection: @groups, as: :group
+
 

--- a/app/views/messages/_index.html.haml
+++ b/app/views/messages/_index.html.haml
@@ -1,0 +1,10 @@
+.group
+  %p.group__name= link_to group.name, group_messages_path(group)
+  %p.group__info
+    - if group.messages.present?
+      - if group.messages.last.text.empty?
+        = "画像が投稿されています"
+      - else
+        = group.messages.last.text
+    - else
+      = "まだメッセージはありません"

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -1,39 +1,26 @@
 .left-contents
-  .user
-    %p.user__name name
-    .user__icon
-      .user__icon__mark
-        = link_to new_group_path do
-          %i.fa.fa-edit
-      .user__icon__mark
-        = link_to edit_user_registration_path do
-          %i.fa.fa-cog
-  .group
-    %p.group__name Oh yeah!!
-    %p.group__info よろしくお願いします
-  .group
-    %p.group__name an an
-    %p.group__info よろしくお願いします
-
+  = render template: "groups/index",  collection: @groups, as: :group
 .right-contents
   .main-group
-    %h3.main-group__name sampleグループ
-    %h3.main-group__member Members: ryousuke maehira
+    %h3.main-group__name= @group.name
+    %h3.main-group__member
+      Members :
+      - @group.users.each do |user|
+        = user.name
     = link_to root_path do
       .main-group__edit Edit
   .chatspace
     .chatspace-content
-      .chatspace-content__member ryousukemaehira
-      .chatspace-content__post-time 2016/10/02 06:27:07
-      .chatspace-content__chat なるほど
-    .chatspace-content
-      .chatspace-content__member ryousukemaehira
-      .chatspace-content__post-time 2016/10/02 06:27:07
-      .chatspace-content__chat なるほど
-    %footer.form-box
-      = form_for ( [@group, @message] ), url: {action: :create} do |f|
-        = f.text_field :text, class: "form-box__text-field", placeholder: "Type a text"
-        %label.form-box__picture-set
-          = f.file_field :image, class: "form-box__picture-set__field"
-          %i.fa.fa-file-picture-o.fa-fw
-        = f.submit value: "Send", class: "form-box__button"
+      .chatspace-content
+        - @messages.each do |message|
+          .chatspace-content__member= message.user.name
+          .chatspace-content__post-time= message.created_at
+          .chatspace-content__chat= message.text
+          .chatspace-content__chat= image_tag message.image.to_s
+      %footer.form-box
+        = form_for ( [@group, @message] ) do |f|
+          = f.text_field :text, class: "form-box__text-field", placeholder: "Type a text"
+          %label.form-box__picture-set
+            = f.file_field :image, class: "form-box__picture-set__field"
+            %i.fa.fa-file-picture-o.fa-fw
+          = f.submit value: "Send", class: "form-box__button"


### PR DESCRIPTION
# What
・チャットのやりとりをメッセージコントローラーのインデックスアクションのビューに反映させるようにした
・グループコントローラーとメッセージコントローラーのインデックスアクションの左側に投稿状況に応じたメッセージを表示する処理
・グループコントローラーとメッセージコントローラーのインデックスアクションの左側で、グループ名のところをクリックすると遷移する処理